### PR TITLE
fix: handle edgecase where incorrect URL is displayed on dashboard

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -569,6 +569,11 @@ func reconstructURL(router TraefikRouter, entryPoints map[string]TraefikEntryPoi
 		return fmt.Sprintf("%s://%s%s", protocol, hostname, path)
 	}
 
+	// Edgecase where protocol is http and port 443 due to http-to-https redirect
+	if protocol == "http" && port == "443" {
+		return fmt.Sprintf("https://%s%s", hostname, path)
+	}
+
 	return fmt.Sprintf("%s://%s%s:%s", protocol, hostname, path, port)
 }
 


### PR DESCRIPTION
This PR handles an edgecase where Traefik does a http-to-https redirect, but the service itself only uses http, see the example below.. The resulting URL on the dashboard will be: `http://jellyfin.mydomain.com:443`. This PR update the logic to display `jellyfin.mydomain.com`. Displaying the `https://` prefix would look nicer imo, maybe a configuration option could be added as part of https://github.com/dannybouwers/trala/pull/20?

```yaml
labels:
  - "traefik.enable=true"
  - "traefik.http.routers.Jellyfin.entrypoints=https"
  - "traefik.http.routers.Jellyfin.rule=Host(`jellyfin.mydomain.com`)"
  - "traefik.http.routers.Jellyfin.priority=1000"
  - "traefik.http.routers.Jellyfin.tls=true"
  - "traefik.http.routers.Jellyfin.service=jellyfin"
  - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
  - "traefik.docker.network=proxy"
```