### PR TITLE
feat: add secure Traefik API access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,46 @@ The application uses the **router name** from your Traefik configuration (the pa
 
 ---
 
+## 🔒 Secure Traefik API Access (Advanced)
+
+Instead of using `--api.insecure=true` in your Traefik configuration, you can create a dedicated router for the API. This approach is more secure as it allows fine-grained control over API access.
+
+### How It Works
+
+If TraLa is deployed in the same Docker network as Traefik, the router should also work within the network. This can be accomplished by adding the internal Traefik hostname as a host in the router of Traefik.
+
+### Example Configuration
+
+```yaml
+version: '3.8'
+
+services:
+  traefik:
+    image: "traefik:v3.0"
+    hostname: traefik # <-- specify the hostname for this container
+    # ... your existing traefik configuration ...
+    command:
+      # ...
+      - --api # Secure API
+      - --entrypoints.web.address=:80
+      # - ...
+    labels:
+      # ...
+      # Dashboard & API
+      - traefik.http.routers.traefik-api.entrypoints=web
+      - traefik.http.routers.traefik-api.rule=Host(`traefik`) && PathPrefix(`/api`) # <-- use the container hostname in the router rule
+      - traefik.http.routers.traefik-api.service=api@internal
+
+  trala:
+    # ... your existing traefik configuration ...
+    environment:
+      - TRAEFIK_API_HOST=http://traefik # <-- specify the hostname of the traefik container and the port of the entrypoint (if not protocol default)
+```
+
+With this configuration, you can remove the `--api.insecure=true` flag from your Traefik configuration, making your setup more secure. TraLa will automatically ignore the service created for connecting to Traefik's API.
+
+---
+
 ## 🔧 Configuration
 
 The application is configured using environment variables:

--- a/server/main.go
+++ b/server/main.go
@@ -291,17 +291,30 @@ func servicesHandler(w http.ResponseWriter, r *http.Request) {
 func processRouter(router TraefikRouter, entryPoints map[string]TraefikEntryPoint, ch chan<- Service) {
 	routerName := strings.Split(router.Name, "@")[0]
 
+	serviceURL := reconstructURL(router, entryPoints)
+
+	if serviceURL == "" {
+		debugf("Could not reconstruct URL for router %s from rule: %s", routerName, router.Rule)
+		return
+	}
+
 	// Check if this router should be excluded
 	if isExcluded(routerName) {
 		debugf("Excluding router: %s", routerName)
 		return
 	}
 
-	serviceURL := reconstructURL(router, entryPoints)
-
-	if serviceURL == "" {
-		debugf("Could not reconstruct URL for router %s from rule: %s", routerName, router.Rule)
-		return
+	// Check if this is the Traefik API service and exclude it
+	traefikAPIHost := os.Getenv("TRAEFIK_API_HOST")
+	if traefikAPIHost != "" {
+		if !strings.HasPrefix(traefikAPIHost, "http") {
+			traefikAPIHost = "http://" + traefikAPIHost
+		}
+		apiURL := traefikAPIHost + "/api"
+		if serviceURL == apiURL {
+			debugf("Excluding router %s because it's the Traefik API service", routerName)
+			return
+		}
 	}
 
 	debugf("Processing router: %s, URL: %s", routerName, serviceURL)
@@ -340,7 +353,7 @@ func findBestIconURL(routerName, serviceURL string) string {
 	}
 
 	// Priority 2: Fuzzy search against selfh.st icons
-	routerNameReplaced = strings.ReplaceAll(routerName, " ", "-")
+	routerNameReplaced := strings.ReplaceAll(routerName, " ", "-")
 	if iconURL := findSelfHstIcon(routerNameReplaced); iconURL != "" {
 		debugf("[%s] Found icon via fuzzy search: %s", routerNameReplaced, iconURL)
 		return iconURL


### PR DESCRIPTION
 * Add instruction to use TraLa without `-- api.insecure=true`.
 * Automatically ignore service if router url is exactly the url of the API so it will not show up on the dashboard.