### PR TITLE
Add version number to frontend

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,13 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -50,4 +57,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            # disabled if major zero
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
@@ -47,4 +49,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 

--- a/dockerfile
+++ b/dockerfile
@@ -4,6 +4,11 @@ FROM golang:1.25-alpine AS builder
 # Install build essentials for static compilation
 RUN apk add --no-cache build-base
 
+# Accept version as build argument
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TIME=unknown
+
 WORKDIR /app
 
 # Copy Go module files and download dependencies
@@ -13,8 +18,8 @@ RUN go mod download
 # Copy the source code
 COPY server/main.go .
 
-# Build the application as a statically linked binary.
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /server .
+# Build the application as a statically linked binary with version info
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}" -o /server .
 
 
 ### STAGE 2: Production ###

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
         </div>
     </div>
     
-    <footer class="fixed bottom-0 right-0 p-4">
+    <footer class="fixed bottom-0 right-0 p-4 flex items-center">
+        <a id="version-link" href="#" target="_blank" rel="noopener noreferrer" class="text-gray-400 text-sm mr-4 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"><span id="version-number">loading...</span></a>
         <a href="https://github.com/dannybouwers/trala" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.165 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.868-.014-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.031-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.03 1.595 1.03 2.688 0 3.848-2.338 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.001 10.001 0 0022 12c0-5.523-4.477-10-10-10z" clip-rule="evenodd" />
@@ -223,10 +224,38 @@
             
             searchForm.addEventListener('submit', (e) => { e.preventDefault(); if (searchInput.value) { window.open(`${SEARCH_ENGINE_URL}${encodeURIComponent(searchInput.value)}`, '_blank'); } });
 
+            // Fetch and display version information
+            const fetchVersion = async () => {
+                try {
+                    const response = await fetch('/api/version');
+                    if (response.ok) {
+                        const versionInfo = await response.json();
+                        const versionElement = document.getElementById('version-number');
+                        const versionLink = document.getElementById('version-link');
+                        if (versionElement && versionLink) {
+                            const version = versionInfo.version || 'unknown';
+                            versionElement.textContent = version;
+                            versionLink.href = `https://github.com/dannybouwers/trala/releases/tag/${version}`;
+                        }
+                    }
+                } catch (error) {
+                    console.error('Error fetching version:', error);
+                    const versionElement = document.getElementById('version-number');
+                    const versionLink = document.getElementById('version-link');
+                    if (versionElement && versionLink) {
+                        versionElement.textContent = 'dev';
+                        versionLink.href = 'https://github.com/dannybouwers/trala/releases';
+                    }
+                }
+            };
+
             const startApp = async () => {
                 updateGreeting();
                 updateClock();
-                setInterval(updateClock, 6000); 
+                setInterval(updateClock, 6000);
+
+                // Fetch version information
+                await fetchVersion();
 
                 await fetchAndProcessServices();
                 if (refreshIntervalId) clearInterval(refreshIntervalId);

--- a/server/main.go
+++ b/server/main.go
@@ -21,6 +21,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Version information set at build time
+var (
+	version   string
+	commit    string
+	buildTime string
+)
+
 // --- Structs ---
 
 // TraefikRouter represents the essential fields from the Traefik API response.
@@ -48,6 +55,13 @@ type Service struct {
 	URL        string `json:"url"`
 	Priority   int    `json:"priority"`
 	Icon       string `json:"icon"`
+}
+
+// VersionInfo represents the application version information
+type VersionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"buildTime"`
 }
 
 type TraefikConfig struct {
@@ -243,6 +257,18 @@ func servicesHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(finalServices)
+}
+
+// versionHandler returns the application version information
+func versionHandler(w http.ResponseWriter, r *http.Request) {
+	versionInfo := VersionInfo{
+		Version:   version,
+		Commit:    commit,
+		BuildTime: buildTime,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(versionInfo)
 }
 
 // --- Data Processing & Icon Finding ---
@@ -802,6 +828,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/services", servicesHandler)
+	mux.HandleFunc("/api/version", versionHandler)
 	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticPath))))
 	mux.Handle("/icons/", http.StripPrefix("/icons/", http.FileServer(http.Dir("/icons"))))
 	mux.HandleFunc("/", serveHTMLTemplate)


### PR DESCRIPTION
* Add annotations to docker image
* The Docker build embeds version information in the Go binary
* When the application runs, users can see the version in the footer of the dashboard
* The version is also available via the `/api/version` endpoint
* Clicking on the version link takes users to the specific release page on GitHub