### PR TITLE
Frontend config API and compiled Tailwind CSS

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,18 @@
-### STAGE 1: Build Go Application ###
+### STAGE 1: Build Tailwind CSS ###
+FROM node:24-alpine AS tailwind-builder
+
+WORKDIR /app
+
+# Copy Tailwind configuration and source files
+COPY src/input.css /app/src/
+COPY index.html /app/src/
+
+# Install Tailwind CSS and build it
+RUN npm install tailwindcss @tailwindcss/cli
+# Create a minimal tailwind.config.js file
+RUN npx @tailwindcss/cli -i /app/src/input.css -o /app/src/output.css
+
+### STAGE 2: Build Go Application ###
 FROM golang:1.25-alpine AS builder
 
 # Install build essentials for static compilation
@@ -22,7 +36,7 @@ COPY server/main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}" -o /server .
 
 
-### STAGE 2: Production ###
+### STAGE 3: Production ###
 # Start with a minimal Alpine image
 FROM alpine:3.22
 
@@ -34,6 +48,9 @@ COPY --from=builder /server /app/server
 
 # Copy the static frontend files into a 'static' directory
 COPY static/* /app/static/
+
+# Copy the compiled Tailwind CSS from the tailwind-builder stage
+COPY --from=tailwind-builder /app/src/output.css /app/static/output.css
 
 # Copy the html template into a 'template' directory
 COPY index.html /app/template/index.html

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TraLa - Traefik Landing Page</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="static/output.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -69,8 +69,9 @@
 
     <script type="module">
         const API_URL = '/api/services';
-        const SEARCH_ENGINE_URL = '%%SEARCH_ENGINE_URL%%';
-        const REFRESH_INTERVAL_SECONDS = parseInt('%%REFRESH_INTERVAL_SECONDS%%', 10);
+        // Defaults. These will be overridden by frontend config fetch
+        let SEARCH_ENGINE_URL = 'https://www.google.com/search?q=';
+        let REFRESH_INTERVAL_SECONDS = 30;
 
         const serviceGrid = document.getElementById('service-grid');
         const searchInput = document.getElementById('search-input');
@@ -249,7 +250,24 @@
                 }
             };
 
+            // Fetch frontend configuration
+            const fetchFrontendConfig = async () => {
+                try {
+                    const response = await fetch('/api/frontend-config');
+                    if (response.ok) {
+                        const config = await response.json();
+                        SEARCH_ENGINE_URL = config.searchEngineURL;
+                        REFRESH_INTERVAL_SECONDS = config.refreshIntervalSeconds;
+                    }
+                } catch (error) {
+                    console.error('Error fetching frontend config:', error);
+                }
+            };
+
             const startApp = async () => {
+                // Fetch frontend configuration first
+                await fetchFrontendConfig();
+                
                 updateGreeting();
                 updateClock();
                 setInterval(updateClock, 6000);

--- a/src/input.css
+++ b/src/input.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";


### PR DESCRIPTION
Added an API to get frontend configuration (`SearchEngineURL` and `RefreshIntervalSeconds`). This fixed complication errors for Tailwind. A third stage added to `dockerfile` to compile the CSS (and eliminate the console warning).