### PR TITLE
Feature/traefik api authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,16 @@ services:
 
 Supported environment variables are shown below.
 
-| Variable                       | Description                                                                                                                                       | Default                                      | Required |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------- |
-| `TRAEFIK_API_HOST`             | The full base URL of your Traefik API. From within Docker, this is typically `http://traefik:8080`.                                               | `(none)`                                     | **Yes**  |
-| `SELFHST_ICON_URL`             | Base URL of the Selfhst icon endpoint. Customize if you are hosting your own local instance.                                                      | `https://cdn.jsdelivr.net/gh/selfhst/icons/` | No       |
-| `REFRESH_INTERVAL_SECONDS`     | The interval in seconds at which the service list automatically refreshes.                                                                        | `30`                                         | No       |
-| `SEARCH_ENGINE_URL`            | The URL for the external search engine. The search query will be appended to this URL.                                                            | `https://www.google.com/search?q=`           | No       |
-| `LOG_LEVEL`                    | Set to `debug` for verbose logging of the icon-finding process. Any other value is silent.                                                        | `info`                                       | No       |
-| `TRAEFIK_BASIC_AUTH_USERNAME`  | Sets the username for the Traefik basic auth scheme if enabled.                                                                                   | `(none)`                                     | No       |
-| `TRAEFIK_BASIC_AUTH_PASSWORD`  | Sets the password for the Traefik basic auth scheme if enabled.                                                                                   | `(none)`                                     | No       |
-| `TRAEFIK_BASIC_AUTH_FILE`      | Sets the file path from where to load the password for the Traefik basic auth scheme if enabled. Takes precedence over setting password directly. | `(none)`                                     | No       |
+| Variable                           | Description                                                                                                                                       | Default                                      | Required |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------- |
+| `TRAEFIK_API_HOST`                 | The full base URL of your Traefik API. From within Docker, this is typically `http://traefik:8080`.                                               | `(none)`                                     | **Yes**  |
+| `SELFHST_ICON_URL`                 | Base URL of the Selfhst icon endpoint. Customize if you are hosting your own local instance.                                                      | `https://cdn.jsdelivr.net/gh/selfhst/icons/` | No       |
+| `REFRESH_INTERVAL_SECONDS`         | The interval in seconds at which the service list automatically refreshes.                                                                        | `30`                                         | No       |
+| `SEARCH_ENGINE_URL`                | The URL for the external search engine. The search query will be appended to this URL.                                                            | `https://www.google.com/search?q=`           | No       |
+| `LOG_LEVEL`                        | Set to `debug` for verbose logging of the icon-finding process. Any other value is silent.                                                        | `info`                                       | No       |
+| `TRAEFIK_BASIC_AUTH_USERNAME`      | Sets the username for the Traefik basic auth scheme if enabled.                                                                                   | `(none)`                                     | No       |
+| `TRAEFIK_BASIC_AUTH_PASSWORD`      | Sets the password for the Traefik basic auth scheme if enabled.                                                                                   | `(none)`                                     | No       |
+| `TRAEFIK_BASIC_AUTH_PASSWORD_FILE` | Sets the file path from where to load the password for the Traefik basic auth scheme if enabled. Takes precedence over setting password directly. | `(none)`                                     | No       |
 
 ### Service Exclusion
 
@@ -365,7 +365,7 @@ services:
   trala:
     [...]
     environment:
-      - TRAEFIK_BASIC_AUTH_FILE=/run/secrets/basic_auth_password
+      - TRAEFIK_BASIC_AUTH_PASSWORD_FILE=/run/secrets/basic_auth_password
 ```
 
 ### Environment Variable

--- a/server/main.go
+++ b/server/main.go
@@ -1119,7 +1119,7 @@ func loadConfiguration() {
 	if v := os.Getenv("TRAEFIK_BASIC_AUTH_PASSWORD"); v != "" {
 		config.Environment.Traefik.BasicAuth.Password = v
 	}
-	if v := os.Getenv("TRAEFIK_BASIC_AUTH_FILE"); v != "" {
+	if v := os.Getenv("TRAEFIK_BASIC_AUTH_PASSWORD_FILE"); v != "" {
 		config.Environment.Traefik.BasicAuth.PasswordFile = v
 	}
 	if v := os.Getenv("LOG_LEVEL"); v != "" {


### PR DESCRIPTION
This PR adds Basic Auth capability to Trala. This allows users to properly secure access to the Traefik API, such that other services cannot query the API. Basic Auth credentials can either be specified via the configuration file, or as Environment variables.

Closes #25.