### PR TITLE
feat(i18n): add French translation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Everything automatic can be overwritten with a single YAML configuration file, p
 - **Live Search & Sort:** Instantly filter and sort your services by name, URL, or priority.
 - **External Search:** Use the search bar to quickly search the web with your configured search engine.
 - **Lightweight & Multi-Arch:** Built with Go and a minimal Alpine base, the Docker image is small and compatible with `amd64` and `arm64` architectures.
-- **Multi-Language Support:** Available in English, German, and Dutch.
+- **Multi-Language Support:** Available in English, German Dutch and French.
 
 ## Quick start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Everything automatic can be overwritten with a single YAML configuration file, p
 - **Live Search & Sort:** Instantly filter and sort your services by name, URL, or priority.
 - **External Search:** Use the search bar to quickly search the web with your configured search engine.
 - **Lightweight & Multi-Arch:** Built with Go and a minimal Alpine base, the Docker image is small and compatible with `amd64` and `arm64` architectures.
-- **Multi-Language Support:** Available in English, German Dutch and French.
+- **Multi-Language Support:** Available in English, German, Dutch and French.
 
 ## Quick start
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ environment:
   # Log level: info, debug
   log_level: info
 
-  # Language: en, de, nl
+  # Language: en, de, nl, fr
   language: nl
 
   # Smart grouping configuration
@@ -88,7 +88,7 @@ services:
 | `REFRESH_INTERVAL_SECONDS` | Auto-refresh interval | `30` |
 | `SEARCH_ENGINE_URL` | Search engine URL | `https://www.google.com/search?q=` |
 | `LOG_LEVEL` | Log level: `info` or `debug` | `info` |
-| `LANGUAGE` | Language: `en`, `de`, or `nl` | `en` |
+| `LANGUAGE` | Language: `en`, `de`, `nl` or `fr` | `en` |
 | `SELFHST_ICON_URL` | Base URL for icon endpoint | `https://cdn.jsdelivr.net/gh/selfhst/icons/` |
 
 ### Grouping Variables
@@ -117,6 +117,7 @@ TraLa supports three languages:
 - `en` — English (default)
 - `de` — German
 - `nl` — Dutch
+- `fr` — French
 
 Set the language using the `LANGUAGE` environment variable or the `language` key in the configuration file.
 

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -1,0 +1,47 @@
+# Title of the homepage
+title: "TraLa - Page de destination de Traefik"
+
+# Error message for a general error
+error: "Oups, quelque chose s'est mal passé."
+
+# Error message when services cannot be loaded
+fetch_error: "Impossible de récupérer les services."
+
+# Label for the search function
+search: "Recherche"
+
+# Tooltip for the clear search button
+clear_search: "Effacer la recherche"
+
+# Placeholder text for the search field
+search_placeholder: "Filtrer les services ou rechercher sur le web..."
+
+# Button label to sort by the name of a service
+name: "Nom"
+
+# Button label to sort by the URL of a service
+url: "URL"
+
+# Button label to sort by the priority of a service
+priority: "Priorité"
+
+# Greeting for the night (00:00 - 5:59)
+greeting_night: "Bonne nuit"
+
+# Greeting for the morning (6:00 - 11:59)
+greeting_morning: "Bonjour"
+
+# Greeting for the afternoon (12:00 - 17:59)
+greeting_afternoon: "Bon après-midi"
+
+# Greeting for the evening (18:00 - 23:59)
+greeting_evening: "Bonne soirée"
+
+# Button label for grouping toggle
+grouping: "Regroupement"
+
+# Button label for expand/collapse all groups
+expand_collapse_all: "Développer/Réduire tout"
+
+# Fallback group name for uncategorized services
+uncategorized: "Non classé"


### PR DESCRIPTION
Adds `translations/fr.yaml` providing a complete French translation, and updates `docs/README.md` and `docs/configuration.md` to list French as a supported language alongside English, German, and Dutch.