### PR TITLE
fix(website): migrate remarkPlugins to unified() processor

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import remarkGithubAlerts from 'remark-github-alerts';
 import tailwindcss from '@tailwindcss/vite';
@@ -14,7 +15,9 @@ export default defineConfig({
   ],
 
   markdown: {
-    remarkPlugins: [remarkGithubAlerts],
+    processor: unified({
+      remarkPlugins: [remarkGithubAlerts]
+    }),
     shikiConfig: {
       themes: {
         light: 'github-light',


### PR DESCRIPTION
## Summary
- Move `remarkGithubAlerts` from deprecated `markdown.remarkPlugins` into a `unified()` processor from `@astrojs/markdown-remark`
- Resolves Astro deprecation warning about `markdown.remarkPlugins`

## Changes
- Update `website/astro.config.mjs` to use the new `markdown.processor` API with `unified()`

## Test Plan
- Run `npm run build` in `website/` and verify no Astro deprecation warnings