### PR TITLE
📝 docs(configuration): update version references from 3.3 to 4.0

### DIFF
--- a/demo/configuration.yml
+++ b/demo/configuration.yml
@@ -1,7 +1,7 @@
 # TraLa Configuration File
-# Version 3.3
+# Version 4.0
 
-version: 3.3
+version: 4.0
 
 # Environment settings (optional, environment variables take precedence)
 environment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ A sample configuration file:
 
 ```yaml
 # TraLa Configuration File
-version: 3.3
+version: 4.0
 
 # Environment settings
 environment:

--- a/docs/multi_host.md
+++ b/docs/multi_host.md
@@ -10,7 +10,7 @@ Add a `traefik` block that contains a list of `instances`. Each instance support
 
 ```yaml
 # configuration.yml
-version: 3.3
+version: 4.0
 
 environment:
   traefik:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -125,7 +125,7 @@ A configuration file provides more customization options:
 
 ```yaml
 # configuration.yml
-version: 3.3
+version: 4.0
 
 environment:
   selfhst_icon_url: https://cdn.jsdelivr.net/gh/selfhst/icons/


### PR DESCRIPTION
## What does this PR do?

update version for config file to 4.0 since the introduction of `traefik.instances` is breaking to old versions of TraLa.

## Type of change

<!-- Mark the ones that apply. -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🎨 UI/UX improvement
- [x] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🔧 Tests or tooling
- [ ] ⬆️ Dependency update

## How was this tested?

- [x] Application tested via the demo stack (`cd demo && docker compose up -d`)
- [ ] Website tested (`cd website && npm run build` / `npm run dev`)
- [ ] Not applicable (e.g. docs-only change)

## How was AI used while building this?

Pick the option that best describes your process. -->

- [x] 🧑‍💻 **Fully manual** — I wrote and reviewed all of the code myself.
- [ ] 💡 **AI as a helper** — I wrote the code; AI helped with suggestions, docs, or explanations.
- [ ] 🤝 **Collaborative** — AI and I built it together; I understand and can explain every change.
- [ ] 🤖 **Mostly AI-written** — AI generated most of the code; I reviewed and tested it.
- [ ] ❓ **Entirely AI-generated** — The code was written and tested by AI and I don't fully understand all of it yet.

## Anything else reviewers should know?

Min config version in `internal/config/config.go` doesn't need to be increased since the multi-host code is compatible with old config files.