### PR TITLE
📝 docs: standardize language references using ISO 639-1 codes and update weblate urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions are welcome! Please read the [development guide](docs/development.
 
 [![Translation status](https://hosted.weblate.org/widget/trala/trala/matrix-auto.svg)](https://hosted.weblate.org/engage/trala/)
 
-TraLa is available in multiple languages, and translations are managed through [Weblate](https://hosted.weblate.org/git/trala/trala/). You can:
+TraLa is available in multiple languages, and translations are managed through [Weblate](https://hosted.weblate.org/projects/trala/). You can:
 
 - Submit translation suggestions as an anonymous user
 - Edit existing translations if you have a registered account

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A modern, dynamic dashboard for Traefik services.
 - **Smart Grouping** — Automatically group services based on tags
 - **Light/Dark Mode** — Automatic theme based on OS settings
 - **Manual Services** — Add custom services not managed by Traefik
-- **Multi-Language** — Available in English, German, and Dutch
+- **Multi-Language** — Available in e.g. English, German, Dutch and French
 - **Multi-Arch** — Built for amd64 and arm64 architectures
 - **Multi-Host** — Aggregate services from multiple Traefik instances into one dashboard
 
@@ -50,7 +50,7 @@ Contributions are welcome! Please read the [development guide](docs/development.
 
 ## 🌐 Translations
 
-[![Translation status](https://hosted.weblate.org/widget/trala/trala/svg-badge.svg)](https://hosted.weblate.org/engage/trala/)
+[![Translation status](https://hosted.weblate.org/widget/trala/trala/matrix-auto.svg)](https://hosted.weblate.org/engage/trala/)
 
 TraLa is available in multiple languages, and translations are managed through [Weblate](https://hosted.weblate.org/git/trala/trala/). You can:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Everything automatic can be overwritten with a single YAML configuration file, p
 - **Live Search & Sort:** Instantly filter and sort your services by name, URL, or priority.
 - **External Search:** Use the search bar to quickly search the web with your configured search engine.
 - **Lightweight & Multi-Arch:** Built with Go and a minimal Alpine base, the Docker image is small and compatible with `amd64` and `arm64` architectures.
-- **Multi-Language Support:** Available in English, German, Dutch and French.
+- **Multi-Language Support:** Available in e.g. English, German, Dutch and French. See [Weblate](https://hosted.weblate.org/git/trala/trala/) for all available languages.
 
 ## Quick start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Everything automatic can be overwritten with a single YAML configuration file, p
 - **Live Search & Sort:** Instantly filter and sort your services by name, URL, or priority.
 - **External Search:** Use the search bar to quickly search the web with your configured search engine.
 - **Lightweight & Multi-Arch:** Built with Go and a minimal Alpine base, the Docker image is small and compatible with `amd64` and `arm64` architectures.
-- **Multi-Language Support:** Available in e.g. English, German, Dutch and French. See [Weblate](https://hosted.weblate.org/git/trala/trala/) for all available languages.
+- **Multi-Language Support:** Available in e.g. English, German, Dutch and French. See [Weblate](https://hosted.weblate.org/projects/trala/) for all available languages.
 
 ## Quick start
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ environment:
   # Log level: info, debug
   log_level: info
 
-  # Language: en, de, nl, fr
+  # Language: ISO 639-1 codes (e.g. en, de, nl, fr)
   language: nl
 
   # Smart grouping configuration
@@ -100,7 +100,7 @@ services:
 | `REFRESH_INTERVAL_SECONDS` | Auto-refresh interval | `30` |
 | `SEARCH_ENGINE_URL` | Search engine URL | `https://www.google.com/search?q=` |
 | `LOG_LEVEL` | Log level: `info` or `debug` | `info` |
-| `LANGUAGE` | Language: `en`, `de`, `nl` or `fr` | `en` |
+| `LANGUAGE` | Language: ISO 639-1 code (see [Weblate](https://hosted.weblate.org/projects/trala/) for available translations) | `en` |
 | `SELFHST_ICON_URL` | Base URL for icon endpoint | `https://cdn.jsdelivr.net/gh/selfhst/icons/` |
 
 ### Grouping Variables
@@ -164,7 +164,9 @@ When an `instances` list is present (with more than one entry), TraLa runs in **
 
 ## Language Settings
 
-TraLa supports three languages:
+TraLa supports multiple languages. Translations are managed via [Weblate](https://hosted.weblate.org/projects/trala/). Languages are set using [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) two-letter language codes.
+
+Available languages include, but are not limited to:
 
 - `en` — English (default)
 - `de` — German
@@ -172,6 +174,8 @@ TraLa supports three languages:
 - `fr` — French
 
 Set the language using the `LANGUAGE` environment variable or the `language` key in the configuration file.
+
+To contribute a new translation, visit the [TraLa project on Weblate](https://hosted.weblate.org/engage/trala/).
 
 ## Logging
 


### PR DESCRIPTION
# Pull Request

Thanks for contributing to TraLa! 🎉 Whether it's a bug fix, a new feature, or a
docs tweak, every contribution is welcome and appreciated.

## What does this PR do?

Standardizes language references across the README and documentation to use ISO 639-1 codes, and updates Weblate project URLs to the current format. Language availability is now described more flexibly ("e.g.") rather than as fixed lists, and the Weblate badge uses the matrix-auto format.

## Type of change

<!-- Mark the ones that apply. -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🎨 UI/UX improvement
- [x] 📖 Documentation
- [ ] 🌍 Translation
- [ ] 🔧 Tests or tooling
- [ ] ⬆️ Dependency update

## How was this tested?

<!-- Tell us how you verified the change works. -->

- [ ] Application tested via the demo stack (`cd demo && docker compose up -d`)
- [ ] Website tested (`cd website && npm run build` / `npm run dev`)
- [x] Not applicable (e.g. docs-only change)

## How was AI used while building this?

<!-- Be honest — no judgment either way! This helps reviewers calibrate their feedback.
Pick the option that best describes your process. -->

- [ ] 🧑‍💻 **Fully manual** — I wrote and reviewed all of the code myself.
- [x] 💡 **AI as a helper** — I wrote the code; AI helped with suggestions, docs, or explanations.
- [ ] 🤝 **Collaborative** — AI and I built it together; I understand and can explain every change.
- [ ] 🤖 **Mostly AI-written** — AI generated most of the code; I reviewed and tested it.
- [ ] ❓ **Entirely AI-generated** — The code was written and tested by AI and I don't fully understand all of it yet.

> If you picked an option toward the bottom, that's completely fine — TraLa is
> itself an AI-assisted project! Just let us know so reviewers can give extra
> guidance and help you learn the parts you're less sure about.

## Anything else reviewers should know?

<!-- Optional: design decisions, things you're unsure about, related issues, etc. -->

Changes in this PR:

- `README.md`: Updated language feature description to use "e.g." and updated Weblate badge/widget URLs to use the matrix-auto format and the current project URL format.
- `docs/README.md`: Added link to Weblate for all available languages.
- `docs/configuration.md`: Updated language references to use ISO 639-1 codes, expanded the language table to include French (`fr`), and added guidance for contributing translations via Weblate.